### PR TITLE
fix(validate): use browser UA with retries for feed validation

### DIFF
--- a/.github/scripts/process_feed_issue.py
+++ b/.github/scripts/process_feed_issue.py
@@ -9,7 +9,8 @@ from datetime import datetime, timezone
 
 import feedparser
 import pandas
-import requests
+
+from fetch_utils import fetch_url
 
 FEEDS_CSV = "./public/feeds.csv"
 REPLACED_BY_PATTERN = re.compile(r"^\s*(\S+)\s+replaced\s+by\s+(\S+)\s*$", re.IGNORECASE)
@@ -90,16 +91,15 @@ def parse_issue_body(body):
     return plain_urls, replaced_by
 
 
-def validate_feed(url, timeout=20):
+def validate_feed(url, timeout=20, retries=3):
     """验证 URL 是否为有效 RSS/Atom feed"""
     try:
-        response = requests.get(url, timeout=timeout, headers={
-            "User-Agent": "Mozilla/5.0 (RSSBlog Source Validator)"
-        })
+        response = fetch_url(url, timeout=timeout, retries=retries)
         response.raise_for_status()
         parsed = feedparser.parse(response.content)
     except Exception as e:
-        return False, str(e), None, None
+        suffix = f" (after {retries} attempts)" if retries > 1 else ""
+        return False, f"{e}{suffix}", None, None
 
     if parsed.bozo and not parsed.entries:
         return False, f"parse error: {parsed.bozo_exception}", None, None

--- a/fetch_utils.py
+++ b/fetch_utils.py
@@ -11,6 +11,34 @@ from concurrent.futures import ThreadPoolExecutor
 from io import BytesIO
 
 
+BROWSER_HEADERS = {
+    "User-Agent": (
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+        "(KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36"
+    ),
+    "Accept": "application/atom+xml, application/rss+xml, application/xml, text/xml, */*",
+    "Accept-Language": "zh-CN,zh;q=0.9,en;q=0.8",
+}
+
+
+def fetch_url(url, timeout=10.0, retries=3, backoff=(2, 4)):
+    """带浏览器伪装与重试的 GET 请求；重试耗尽后抛出最后一次异常"""
+    last_err = None
+    for attempt in range(1, retries + 1):
+        try:
+            resp = requests.get(url, timeout=timeout, headers=BROWSER_HEADERS)
+            if resp.status_code >= 500:
+                raise requests.HTTPError(
+                    f"{resp.status_code} Server Error: {resp.reason} for url: {resp.url}"
+                )
+            return resp
+        except requests.exceptions.RequestException as e:
+            last_err = e
+            if attempt < retries:
+                time.sleep(backoff[min(attempt, len(backoff)) - 1])
+    raise last_err
+
+
 def hash_url(url):
     md5 = hashlib.md5()
     md5.update(url.encode("utf-8"))


### PR DESCRIPTION
Validate feeds with realistic Chrome headers and retry on 5xx/connection errors to bypass EdgeOne Bot 567 blocks, and report attempt count on final failure.