### PR TITLE
fix(validate): add project root to sys.path for fetch_utils import

### DIFF
--- a/.github/scripts/process_feed_issue.py
+++ b/.github/scripts/process_feed_issue.py
@@ -10,6 +10,11 @@ from datetime import datetime, timezone
 import feedparser
 import pandas
 
+sys.path.insert(
+    0,
+    os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))),
+)
+
 from fetch_utils import fetch_url
 
 FEEDS_CSV = "./public/feeds.csv"


### PR DESCRIPTION
Running the script as 'python .github/scripts/process_feed_issue.py' only puts the script dir on sys.path, so fetch_utils was unresolvable in GitHub Actions. Insert the repo root explicitly.